### PR TITLE
Falsum is not compiled correctly in TPTP

### DIFF
--- a/src/gavel/dialects/tptp/compiler.py
+++ b/src/gavel/dialects/tptp/compiler.py
@@ -7,6 +7,10 @@ class TPTPCompiler(Compiler):
     def visit_defined_constant(self, obj: fol.DefinedConstant):
         if obj == fol.DefinedConstant.VERUM:
             return "$true"
+        elif obj == fol.DefinedConstant.FALSUM:
+            return "$false"
+        else:
+            raise NotImplementedError
 
     def parenthesise(self, element: fol.LogicElement):
         if isinstance(element, str):


### PR DESCRIPTION
Currently, when trying to prove the following problem with EProver (or any problem containing `$false`):

```
fof(a1, axiom, $true => (a=b)).
fof(a2, axiom, $true => p(a,c)).
fof(a3, axiom, p(b,c) => $false).
fof(c, conjecture, $false).
```

... this is translated into the following temporary file by the `EProverInterface`:
```
fof(a1, axiom, $true => (a=b)).
fof(a2, axiom, $true => p(a,c)).
fof(a3, axiom, p(b,c) => None).
fof(c, conjecture, None).
```

... which is not what you'd expect, and leads EProver to fail with `eprover: /tmp/tmpesp3hilu:3:(Column 27):(just read ')'): Equal Predicate/Sign ('=') or Negated Equal Predicate ('!=') expected, but Closing bracket (')') read`.

Changing `visit_defined_constant` in `dialects/tptp/compiler.py` to match `dialects/db/compiler.py` seems to fix the problem.