### PR TITLE
Extract symbols from defined constant

### DIFF
--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -362,6 +362,9 @@ class DefinedConstant(Enum):
         elif self == DefinedConstant.FALSUM:
             return "$false"
 
+    def symbols(self):
+        return set()
+
 class Let(LogicElement):
 
     __visit_name__ = "let"

--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -363,7 +363,10 @@ class DefinedConstant(Enum):
             return "$false"
 
     def symbols(self):
-        return set()
+        if self == DefinedConstant.VERUM:
+            return {"$true"}
+        elif self == DefinedConstant.FALSUM:
+            return {"$false"}
 
 class Let(LogicElement):
 


### PR DESCRIPTION
Otherwise .symbol() throws an error for any formula that contains a defined constant.