### PR TITLE
Symbols can not be extracted reliably from formulas

### DIFF
--- a/src/gavel/logic/logic.py
+++ b/src/gavel/logic/logic.py
@@ -256,8 +256,7 @@ class PredicateExpression(LogicElement):
         return "%s(%s)" % (self.predicate, ", ".join(map(str, self.arguments)))
 
     def symbols(self):
-        yield self.predicate
-        return chain(*map(lambda x: x.symbols(), self.arguments))
+        return chain([self.predicate], *map(lambda x: x.symbols(), self.arguments))
 
 
 class TypedVariable(LogicElement):


### PR DESCRIPTION
This is due to an interaction of "return" and "yield". I suggest to change this to a single "return" of a generator chain, see commit message.